### PR TITLE
Bug/remove main elements

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -111,9 +111,9 @@ Best practices
 •	After creating a component, immediately test it for accessibility, performance, and responsiveness. Document the results in the pull request.
 
 
-•   Naming a componont goes as followed: page componets = `pagename-nameofcomponent.svelte`. For reusable components or components that doesnt belong to only 1 page you just type the name of the component like this: namecomponent.svelte. Same goes for global      componetnts like the header.svelte & footer.svelte
+•   Naming a componont is as follows: page components = `pagename-nameofcomponent.svelte`. For reusable components or components that doesnt belong to only one page, you just type the name of the component like this: namecomponent.svelte. Same goes for global   components like the header.svelte & footer.svelte
 
-•   Components are also located in different location depending if its a reusable or page components. Check [issue #174](https://github.com/fdnd-agency/oncollaboration/issues/174#issuecomment-3159842220).
+•   Components are also located in different locations depending on whether they are reusable or page components. Check [issue #174](https://github.com/fdnd-agency/oncollaboration/issues/174#issuecomment-3159842220).
 
 •	Pull requests should be detailed like this one -> [Example Pull Request](https://github.com/fdnd-agency/wogo/pull/24). Include a description of what the code does or adds, test results, before-and-after screenshots, and how it should be reviewed.
 

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -110,6 +110,11 @@ Best practices
 
 •	After creating a component, immediately test it for accessibility, performance, and responsiveness. Document the results in the pull request.
 
+
+•   Naming a componont goes as followed: page componets = `pagename-nameofcomponent.svelte`. For reusable components or components that doesnt belong to only 1 page you just type the name of the component like this: namecomponent.svelte. Same goes for global      componetnts like the header.svelte & footer.svelte
+
+•   Components are also located in different location depending if its a reusable or page components. Check [issue #174](https://github.com/fdnd-agency/oncollaboration/issues/174#issuecomment-3159842220).
+
 •	Pull requests should be detailed like this one -> [Example Pull Request](https://github.com/fdnd-agency/wogo/pull/24). Include a description of what the code does or adds, test results, before-and-after screenshots, and how it should be reviewed.
 
 •	Every pull request must have at least two reviewers who critically evaluates it and provides constructive feedback when needed.

--- a/contributions.md
+++ b/contributions.md
@@ -111,9 +111,9 @@ Best practices
 •	After creating a component, immediately test it for accessibility, performance, and responsiveness. Document the results in the pull request.
 
 
-•   Naming a componont goes as followed: page componets = `pagename-nameofcomponent.svelte`. For reusable components or components that doesnt belong to only 1 page you just type the name of the component like this: namecomponent.svelte. Same goes for global      componetnts like the header.svelte & footer.svelte
+•   Naming a componont is as follows: page components = `pagename-nameofcomponent.svelte`. For reusable components or components that doesnt belong to only one page, you just type the name of the component like this: namecomponent.svelte. Same goes for global   components like the header.svelte & footer.svelte
 
-•   Components are also located in different location depending if its a reusable or page components. Check [issue #174](https://github.com/fdnd-agency/oncollaboration/issues/174#issuecomment-3159842220).
+•   Components are also located in different locations depending on whether they are reusable or page components. Check [issue #174](https://github.com/fdnd-agency/oncollaboration/issues/174#issuecomment-3159842220).
 
 •	Pull requests should be detailed like this one -> [Example Pull Request](https://github.com/fdnd-agency/wogo/pull/24). Include a description of what the code does or adds, test results, before-and-after screenshots, and how it should be reviewed.
 

--- a/contributions.md
+++ b/contributions.md
@@ -110,6 +110,11 @@ Best practices
 
 •	After creating a component, immediately test it for accessibility, performance, and responsiveness. Document the results in the pull request.
 
+
+•   Naming a componont goes as followed: page componets = `pagename-nameofcomponent.svelte`. For reusable components or components that doesnt belong to only 1 page you just type the name of the component like this: namecomponent.svelte. Same goes for global      componetnts like the header.svelte & footer.svelte
+
+•   Components are also located in different location depending if its a reusable or page components. Check [issue #174](https://github.com/fdnd-agency/oncollaboration/issues/174#issuecomment-3159842220).
+
 •	Pull requests should be detailed like this one -> [Example Pull Request](https://github.com/fdnd-agency/wogo/pull/24). Include a description of what the code does or adds, test results, before-and-after screenshots, and how it should be reviewed.
 
 •	Every pull request must have at least two reviewers who critically evaluates it and provides constructive feedback when needed.

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -51,8 +51,7 @@
 <style>
   main {
     margin: auto;
-    margin: 0 auto;
-    margin-bottom: 6rem;
+    margin: 0 auto 6rem auto;
     position: relative;
   }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -46,11 +46,8 @@
     {@render children?.()}
   </main>
 {/if}
-
-<div class="footer">
   <Footer />
-</div>
-
+  
 <style>
   main {
     margin: auto;
@@ -73,14 +70,6 @@
 
     @media (min-width: 120em) {
       margin-top: 5.125em;
-    }
-  }
-
-  .footer {
-    background-color: var(--background-color);
-
-    @media (min-width: 67.5em) {
-      background-color: #f0f0f0;
     }
   }
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -51,7 +51,6 @@
 <style>
   main {
     margin: auto;
-    width: fit-content;
     margin: 0 auto;
     margin-bottom: 6rem;
     position: relative;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -42,9 +42,9 @@
   </main>
 {:else} 
   <Navigation />
-  <div class="content">
+  <main class="content">
     {@render children?.()}
-  </div>
+  </main>
 {/if}
 
 <div class="footer">
@@ -54,8 +54,12 @@
 <style>
   main {
     margin: auto;
+    width: fit-content;
+    margin: 0 auto;
+    margin-bottom: 6rem;
+    position: relative;
   }
-  
+
   .content {
     flex: 1;
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,7 @@
 
 </script>
 
-<main>
+
   <HomeHero {content}/>
   <HomeArrow />
   <CTA />
@@ -18,5 +18,5 @@
   <FAQ {content}/>
   <Partners {logos}/>
 
-</main> 
+
 

--- a/src/routes/contourings/+page.svelte
+++ b/src/routes/contourings/+page.svelte
@@ -4,19 +4,11 @@
   
 </script>
 
-<main>
   <ContouringHeader />
   <Search />
   <Filter activeCategory={data.category} currentPage="contourings"/>
   <ContouringSearchResult ResultsContourings={data.category}/>
   <ContouringContent Contourings={data.contourings}/>
   
-</main>
 
-<style>
-  main {
-    width: 85vw;
-    margin: 0 auto;
-    margin-bottom: 6rem;
-  }
-</style>
+

--- a/src/routes/contourings/[slug]/+page.svelte
+++ b/src/routes/contourings/[slug]/+page.svelte
@@ -6,14 +6,14 @@
 
 <NavBack />
 
-<main>
+<div>
   <ContouringHero Hero={data.contouring}/>
   <ContouringResources Resource={data.contouring}/>
   <ContouringQanda QANDA={data.comments} /> 
-</main>
+</div>
 
 <style>
-  main {
+  div {
     width: fit-content;
     margin: 0 auto;
     margin-bottom: 6rem;

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -9,8 +9,6 @@
   let viewtransition = true;
 </script>
 
-<main>
-
   <ProfileInfo {user} />
   <ProfileNotification {data} />
   <ProfileHistory {data} />
@@ -18,7 +16,7 @@
   <ProfileContourings {data} {viewtransition} />
 
   
-</main>
+
 
 
   

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -4,21 +4,8 @@
   let { data } = $props();
 </script>
 
-<main>
+
   <h1>Search Results</h1>
   <Search />
   <p>Results for: <strong>"{data.query}"</strong></p>
   <SearchResults {data} />
-</main>
-
-<style>
-  main {
-    margin: 1rem;
-    margin-top: 2rem;
-
-    @media (min-width: 1599px) {
-      margin: 4rem;
-    }
-  }
-
-</style>

--- a/src/routes/speakers/[slug]/+page.svelte
+++ b/src/routes/speakers/[slug]/+page.svelte
@@ -7,8 +7,6 @@
   const webinars = data.webinars; 
 </script>
 
-<main>
-
   <SpeakerBackButton />
   {#if speakers}
 
@@ -16,12 +14,3 @@
     <SpeakerFeaturedWebinars {speakers} {webinars} />
     
   {/if}
-
-</main>
-<style>
-
-  main {
-    position: relative;
-  }
-
-</style>

--- a/src/routes/webinars/+page.svelte
+++ b/src/routes/webinars/+page.svelte
@@ -4,7 +4,7 @@
   let { data } = $props();
 </script>
 
-<main>
+
   <WebinarHeader />
 
   <Search />
@@ -12,6 +12,6 @@
   <Filter activeCategory={data.category} currentPage="webinars" />
 
   <FullWebinarSection {data} />
-</main>
+
 
 

--- a/src/routes/webinars/[slug]/+page.svelte
+++ b/src/routes/webinars/[slug]/+page.svelte
@@ -9,7 +9,7 @@
 
 <NavBack />
 
-<main>
+<div>
   <WebinarVideoHeader webinar={data.webinar} />
   <WebinarChapters chapters={parsedChapters} />
   <WebinarTranscript transcript={data.webinar.transcript} />
@@ -18,12 +18,13 @@
   <WebinarResources resources={data.webinar.resources} />
   <WebinarQandA QANDA={data.comments} {parsedChapters}/>
   <WatchNext webinars={data.webinars} formatDate={formatDate} />
-</main>
+</div>
 
 <style>
-  main {
+  div {
     margin-block: 1rem;
     margin-bottom: 6rem;
+    width: 90vw;
   }
  
   ::-webkit-scrollbar {
@@ -42,7 +43,7 @@
   }
 
   @media (min-width: 1080px) {
-    main {
+    div {
       display: grid;
       grid-template-columns: 55% 40%;
       column-gap: 3rem;


### PR DESCRIPTION
## What does this change?
 
This issue fixes issue #188 

In this pr i removed all the mains from all the `page.svelte` files. The old styling from thos mains have been given to the new main inside the `layout.svelte` so that the pages still look the same and good. 

Their are some small exceptions. Instead of removing the main elements inside the slug webinar & slug contouring, i replaced them with a div element cause of certain reasons like one of them used a grid layout around their old main.
 
## How Has This Been Tested?
 
- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test
 
## Images
 
This is how it looked before

<img width="1005" height="785" alt="before" src="https://github.com/user-attachments/assets/c4c1dc57-7e98-49c4-b2c1-08033af741e5" />

And this is it now

<img width="1028" height="647" alt="after" src="https://github.com/user-attachments/assets/edafe4c6-7009-4c96-9c76-8e3a4f8b3134" />

 
 
## How to review

I noticed a little difference in the breakpoint at the home page. I'd like to have your opinion on it @OniWithTheHoodie 
